### PR TITLE
feat: always-available AsyncRead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,15 @@ features = ["all"]
 
 [features]
 default = []
-all = ["json", "reader"]
+all = ["json"]
 json = ["serde", "serde_json"]
-reader = ["tokio", "tokio-util"]
+tokio-io = ["tokio", "tokio-util"]
 
 [dependencies]
 log = "0.4"
 bytes = "0.5"
 futures = "0.3"
+futures_codec = "0.4.1"
 twoway = "0.2"
 http = "0.2"
 httparse = "1.3"
@@ -46,8 +47,3 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2", features = ["full"] }
 hyper = "0.13"
 routerify = "1.1"
-
-[[example]]
-name = "parse_async_read"
-path = "examples/parse_async_read.rs"
-required-features = ["reader"]

--- a/examples/parse_async_read.rs
+++ b/examples/parse_async_read.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "tokio-io"))]
+use futures::io::AsyncRead;
+#[cfg(feature = "tokio-io")]
 use tokio::io::AsyncRead;
+
 // Import multer types.
 use multer::Multipart;
 


### PR DESCRIPTION
Since multer already uses the whole of futures, it feels like using `futures_codec` should be the default.

This switches the `"reader"` feature to be `"tokio-io"`. (semver-major)

----

(note: this is awaiting https://github.com/rousan/multer-rs/pull/18)