### PR TITLE
Ignore extra data before the first boundary

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -67,6 +67,10 @@ impl StreamBuffer {
         twoway::find_bytes(&self.buf, pattern).map(|idx| self.buf.split_to(idx + pattern.len()).freeze())
     }
 
+    pub fn read_to(&mut self, pattern: &[u8]) -> Option<Bytes> {
+        twoway::find_bytes(&self.buf, pattern).map(|idx| self.buf.split_to(idx).freeze())
+    }
+
     pub fn read_field_data(
         &mut self,
         boundary: &str,

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,6 +17,7 @@ pub(crate) struct MultipartState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StreamingStage {
     CleaningPrevFieldData,
+    FindingFirstBoundary,
     ReadingBoundary,
     ReadingFieldHeaders,
     ReadingFieldData,


### PR DESCRIPTION
Fixes #16.

This needs some serious review and deserves more tests (with differently bad or incomplete boundaries), but it's roughly the approach I had in mind.