### PR TITLE
Use intra-doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 An async parser for `multipart/form-data` content-type in Rust.
 
-It accepts a [`Stream`](https://docs.rs/futures/0.3.5/futures/stream/trait.Stream.html) of [`Bytes`](https://docs.rs/bytes/0.5.4/bytes/struct.Bytes.html) as
+It accepts a [`Stream`](https://docs.rs/futures/0.3/futures/stream/trait.Stream.html) of [`Bytes`](https://docs.rs/bytes/1/bytes/struct.Bytes.html) as
 a source, so that It can be plugged into any async Rust environment e.g. any async server.
 
 [Docs](https://docs.rs/multer)

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,6 @@ Run an example:
 
 * [`hyper_server_example`](hyper_server_example.rs) - Shows how to use this crate with Rust HTTP server [hyper](https://hyper.rs/).
 
-* [`parse_async_read`](parse_async_read.rs) - Shows how to parse `multipart/form-data` from an [`AsyncRead`](https://docs.rs/tokio/0.2.20/tokio/io/trait.AsyncRead.html).
+* [`parse_async_read`](parse_async_read.rs) - Shows how to parse `multipart/form-data` from an [`AsyncRead`](https://docs.rs/tokio/1/tokio/io/trait.AsyncRead.html).
 
 * [`prevent_dos_attack`](prevent_dos_attack.rs) - Shows how to apply some rules to prevent potential DoS attacks while handling `multipart/form-data`.

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -62,7 +62,7 @@ impl Constraints {
         }
     }
 
-    /// Specify which fields should be allowed, for any unknown field, the [`next_field`](./struct.Multipart.html#method.next_field) will throw an error.
+    /// Specify which fields should be allowed, for any unknown field, the [`next_field`](crate::Multipart::next_field) will throw an error.
     pub fn allowed_fields<N: Into<String>>(self, allowed_fields: Vec<N>) -> Constraints {
         let allowed_fields = allowed_fields.into_iter().map(|item| item.into()).collect();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,9 +7,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 #[derive(Display)]
 #[non_exhaustive]
 pub enum Error {
-    /// An unknown field is detected when multipart
-    /// [`constraints`](./struct.Constraints.html#method.allowed_fields) are
-    /// added.
+    /// An unknown field is detected when multipart [`constraints`](crate::Constraints::allowed_fields) are added.
     #[display(fmt = "unknown field received: {}", "field_name.as_deref().unwrap_or(\"<unknown>\")")]
     UnknownField { field_name: Option<String> },
 
@@ -28,15 +26,11 @@ pub enum Error {
     #[display(fmt = "failed to read headers: {}", _0)]
     ReadHeaderFailed(httparse::Error),
 
-    /// Failed to decode the field's raw header name to
-    /// [`HeaderName`](https://docs.rs/http/0.2.1/http/header/struct.HeaderName.html)
-    /// type.
+    /// Failed to decode the field's raw header name to [`HeaderName`](http::header::HeaderName) type.
     #[display(fmt = "failed to decode field's raw header name: {:?} {}", name, cause)]
     DecodeHeaderName { name: String, cause: BoxError },
 
-    /// Failed to decode the field's raw header value to
-    /// [`HeaderValue`](https://docs.rs/http/0.2.1/http/header/struct.HeaderValue.html)
-    /// type.
+    /// Failed to decode the field's raw header value to [`HeaderValue`](http::header::HeaderValue) type.
     #[display(fmt = "failed to decode field's raw header value: {}", cause)]
     DecodeHeaderValue { value: Vec<u8>, cause: BoxError },
 
@@ -68,8 +62,7 @@ pub enum Error {
     #[display(fmt = "Content-Type is not multipart/form-data")]
     NoMultipart,
 
-    /// Failed to convert the `Content-Type` to
-    /// [`mime::Mime`](https://docs.rs/mime/0.3.16/mime/struct.Mime.html) type.
+    /// Failed to convert the `Content-Type` to [`mime::Mime`] type.
     #[display(fmt = "Failed to convert Content-Type to `mime::Mime` type: {}", _0)]
     DecodeContentType(mime::FromStrError),
 
@@ -77,8 +70,7 @@ pub enum Error {
     #[display(fmt = "multipart boundary not found in Content-Type")]
     NoBoundary,
 
-    /// Failed to decode the field data as `JSON` in
-    /// [`field.json()`](./struct.Field.html#method.json) method.
+    /// Failed to decode the field data as `JSON` in [`field.json()`](crate::Field::json) method.
     #[cfg(feature = "json")]
     #[cfg_attr(nightly, doc(cfg(feature = "json")))]
     #[display(fmt = "failed to decode field data as JSON: {}", _0)]

--- a/src/field.rs
+++ b/src/field.rs
@@ -15,7 +15,7 @@ use std::task::{Context, Poll};
 
 /// A single field in a multipart stream.
 ///
-/// Its content can be accessed via the [`Stream`](./struct.Field.html#impl-Stream) API or the methods defined in this type.
+/// Its content can be accessed via the [`Stream`] API or the methods defined in this type.
 ///
 /// # Examples
 ///
@@ -40,14 +40,16 @@ use std::task::{Context, Poll};
 ///
 /// ## Warning About Leaks
 ///
-/// To avoid the next field being initialized before this one is done being read or dropped, only one instance per [`Multipart`](./struct.Multipart.html)
-/// instance is allowed at a time. A [`Drop`](https://doc.rust-lang.org/nightly/std/ops/trait.Drop.html) implementation is used to
-/// notify [`Multipart`](./struct.Multipart.html) that this field is done being read.
+/// To avoid the next field being initialized before this one is done being read or dropped, only one instance per [`Multipart`]
+/// instance is allowed at a time. A [`Drop`] implementation is used to
+/// notify [`Multipart`] that this field is done being read.
 ///
-/// If this value is leaked (via [`std::mem::forget()`](https://doc.rust-lang.org/nightly/std/mem/fn.forget.html) or some other mechanism),
-/// then the parent [`Multipart`](./struct.Multipart.html) will never be able to yield the next field in the stream.
-/// The task waiting on the [`Multipart`](./struct.Multipart.html) will also never be notified, which, depending on the executor implementation,
+/// If this value is leaked (via [`std::mem::forget()`] or some other mechanism),
+/// then the parent [`Multipart`] will never be able to yield the next field in the stream.
+/// The task waiting on the [`Multipart`] will also never be notified, which, depending on the executor implementation,
 /// may cause a deadlock.
+///
+/// [`Multipart`]: crate::Multipart
 #[derive(Debug)]
 pub struct Field {
     state: Arc<Mutex<MultipartState>>,
@@ -99,12 +101,12 @@ impl Field {
         self.meta.content_type.as_ref()
     }
 
-    /// Get a map of headers as [`HeaderMap`](https://docs.rs/http/0.2.1/http/header/struct.HeaderMap.html).
+    /// Get a map of headers as [`HeaderMap`].
     pub fn headers(&self) -> &HeaderMap {
         &self.headers
     }
 
-    /// Get the full data of the field as [`Bytes`](https://docs.rs/bytes/0.5.4/bytes/struct.Bytes.html).
+    /// Get the full data of the field as [`Bytes`].
     ///
     /// # Examples
     ///
@@ -139,7 +141,7 @@ impl Field {
 
     /// Stream a chunk of the field data.
     ///
-    /// When the field data has been exhausted, this will return None.
+    /// When the field data has been exhausted, this will return [`None`].
     ///
     /// # Examples
     ///
@@ -204,7 +206,7 @@ impl Field {
     ///
     /// This method fails if the field data is not in JSON format
     /// or it cannot be properly deserialized to target type `T`. For more
-    /// details please see [`serde_json::from_slice`](https://docs.serde.rs/serde_json/fn.from_slice.html);
+    /// details please see [`serde_json::from_slice`].
     #[cfg(feature = "json")]
     #[cfg_attr(nightly, doc(cfg(feature = "json")))]
     pub async fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
@@ -244,7 +246,7 @@ impl Field {
     ///
     /// This method decodes the field data with `BOM sniffing` and with malformed sequences replaced with the `REPLACEMENT CHARACTER`.
     /// You can provide a default encoding for decoding the raw message, while the `charset` parameter of `Content-Type` header is still prioritized.
-    /// For more information about the possible encoding name, please go to [encoding_rs](https://docs.rs/encoding_rs/0.8.22/encoding_rs/) docs.
+    /// For more information about the possible encoding name, please go to [encoding_rs] docs.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! An async parser for `multipart/form-data` content-type in Rust.
 //!
-//! It accepts a [`Stream`](https://docs.rs/futures/0.3.5/futures/stream/trait.Stream.html) of [`Bytes`](https://docs.rs/bytes/0.5.4/bytes/struct.Bytes.html) as
-//! a source, so that It can be plugged into any async Rust environment e.g. any async server.
+//! It accepts a [`Stream`](futures::Stream) of [`Bytes`](bytes::Bytes) as a source, so
+//! that it can be plugged into any async Rust environment e.g. any async server.
 //!
 //! # Examples
 //!
@@ -91,7 +91,7 @@
 //! # tokio::runtime::Runtime::new().unwrap().block_on(run());
 //! ```
 //!
-//! Please refer [`Constraints`](./struct.Constraints.html) for more info.
+//! Please refer [`Constraints`] for more info.
 //!
 //! ## Usage with [hyper.rs](https://hyper.rs/) server
 //!

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -16,14 +16,13 @@ use {tokio::io::AsyncRead, tokio_util::io::ReaderStream};
 
 /// Represents the implementation of `multipart/form-data` formatted data.
 ///
-/// This will parse the source stream into [`Field`](./struct.Field.html) instances via its [`Stream`](https://docs.rs/futures/0.3.5/futures/stream/trait.Stream.html)
-/// implementation.
+/// This will parse the source stream into [`Field`] instances via its [`Stream`] implementation.
 ///
-/// To maintain consistency in the underlying stream, this will not yield more than one [`Field`](./struct.Field.html) at a time.
-/// A [`Drop`](https://doc.rust-lang.org/nightly/std/ops/trait.Drop.html) implementation on [`Field`](./struct.Field.html) is used to signal
+/// To maintain consistency in the underlying stream, this will not yield more than one [`Field`] at a time.
+/// A [`Drop`] implementation on [`Field`] is used to signal
 /// when it's time to move forward, so do avoid leaking that type or anything which contains it.
 ///
-/// The Fields can be accessed via the [`Stream`](./struct.Multipart.html#impl-Stream) API or the methods defined in this type.
+/// The Fields can be accessed via the [`Stream`] API or the methods defined in this type.
 ///
 /// # Examples
 ///
@@ -51,7 +50,7 @@ pub struct Multipart {
 }
 
 impl Multipart {
-    /// Construct a new `Multipart` instance with the given [`Bytes`](https://docs.rs/bytes/0.5.4/bytes/struct.Bytes.html) stream and the boundary.
+    /// Construct a new `Multipart` instance with the given [`Bytes`] stream and the boundary.
     pub fn new<S, O, E, B>(stream: S, boundary: B) -> Multipart
     where
         S: Stream<Item = Result<O, E>> + Send + 'static,
@@ -83,7 +82,7 @@ impl Multipart {
         }
     }
 
-    /// Construct a new `Multipart` instance with the given [`Bytes`](https://docs.rs/bytes/0.5.4/bytes/struct.Bytes.html) stream and the boundary.
+    /// Construct a new `Multipart` instance with the given [`Bytes`] stream and the boundary.
     pub fn new_with_constraints<S, O, E, B>(stream: S, boundary: B, constraints: Constraints) -> Multipart
     where
         S: Stream<Item = Result<O, E>> + Send + 'static,
@@ -113,7 +112,7 @@ impl Multipart {
         }
     }
 
-    /// Construct a new `Multipart` instance with the given [`AsyncRead`][] reader and the boundary.
+    /// Construct a new `Multipart` instance with the given [`AsyncRead`] reader and the boundary.
     ///
     /// # Optional
     ///
@@ -137,8 +136,6 @@ impl Multipart {
     /// # }
     /// # tokio::runtime::Runtime::new().unwrap().block_on(run());
     /// ```
-    ///
-    /// [`AsyncRead`]: https://docs.rs/futures-io/0.3.7/futures_io/trait.AsyncRead.html
     #[cfg(feature = "tokio-io")]
     #[cfg_attr(nightly, doc(cfg(feature = "tokio-io")))]
     pub fn with_reader<R, B>(reader: R, boundary: B) -> Multipart
@@ -150,7 +147,7 @@ impl Multipart {
         Multipart::new(stream, boundary)
     }
 
-    /// Construct a new `Multipart` instance with the given [`AsyncRead`][] reader and the boundary.
+    /// Construct a new `Multipart` instance with the given [`AsyncRead`] reader and the boundary.
     ///
     /// # Optional
     ///
@@ -174,8 +171,6 @@ impl Multipart {
     /// # }
     /// # tokio::runtime::Runtime::new().unwrap().block_on(run());
     /// ```
-    ///
-    /// [`AsyncRead`]: https://docs.rs/futures-io/0.3.7/futures_io/trait.AsyncRead.html
     #[cfg(feature = "tokio-io")]
     #[cfg_attr(nightly, doc(cfg(feature = "tokio-io")))]
     pub fn with_reader_with_constraints<R, B>(reader: R, boundary: B, constraints: Constraints) -> Multipart
@@ -187,14 +182,14 @@ impl Multipart {
         Multipart::new_with_constraints(stream, boundary, constraints)
     }
 
-    /// Yields the next [`Field`](./struct.Field.html) if available.
+    /// Yields the next [`Field`] if available.
     ///
     /// For more info, go to [`Field`](./struct.Field.html#warning-about-leaks).
     pub async fn next_field(&mut self) -> crate::Result<Option<Field>> {
         self.try_next().await
     }
 
-    /// Yields the next [`Field`](./struct.Field.html) with their positioning index as a tuple `(usize, Field)`.
+    /// Yields the next [`Field`] with their positioning index as a tuple `(`[`usize`]`, `[`Field`]`)`.
     ///
     /// For more info, go to [`Field`](./struct.Field.html#warning-about-leaks).
     ///

--- a/src/size_limit.rs
+++ b/src/size_limit.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 /// Represents size limit of the stream to prevent DoS attacks.
 ///
-/// Please refer [`Constraints`](./struct.Constraints.html) for more info.
+/// Please refer [`Constraints`](crate::Constraints) for more info.
 #[derive(Debug)]
 pub struct SizeLimit {
     pub(crate) whole_stream: u64,
@@ -12,7 +12,7 @@ pub struct SizeLimit {
 }
 
 impl SizeLimit {
-    /// Creates a default size limit which is [`std::u64::MAX`](https://doc.rust-lang.org/stable/std/u64/constant.MAX.html) for the whole stream
+    /// Creates a default size limit which is [`u64::MAX`] for the whole stream
     /// and for each field.
     pub fn new() -> SizeLimit {
         SizeLimit::default()
@@ -30,7 +30,7 @@ impl SizeLimit {
         self
     }
 
-    /// Sets size limit for a specific field, it overrides the `per_field` value for this field.
+    /// Sets size limit for a specific field, it overrides the [`per_field`](Self::per_field) value for this field.
     ///
     /// It is useful when you want to set a size limit on a textual field which will be stored in memory
     /// to avoid potential DoS attacks from attackers running the server out of memory.


### PR DESCRIPTION
This switches the crate to using intra-doc links where possible. It should hopefully make the documentation easier to maintain.