### PR TITLE
Correctly handle transport-padding after boundaries.

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -20,6 +20,8 @@ pub(crate) enum StreamingStage {
     CleaningPrevFieldData,
     FindingFirstBoundary,
     ReadingBoundary,
+    DeterminingBoundaryType,
+    ReadingTransportPadding,
     ReadingFieldHeaders,
     ReadingFieldData,
     Eof,


### PR DESCRIPTION
Fixes #25.

I'm also installing `cargo-fuzz` so that I can try it out with these changes and (if wanted) add some transport-padding to the seeds.