### PR TITLE
Set `doc(cfg(...))` on feature gated APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["all"]
@@ -46,6 +45,9 @@ tokio-util = { version = "0.6", features = ["io"],  optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 hyper = { version = "0.14", features = ["server", "http1", "stream", "tcp"] }
+
+[build-dependencies]
+version_check = "0.9"
 
 [[example]]
 name = "parse_async_read"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["all"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if let Some(true) = version_check::is_feature_flaggable() {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,7 @@ pub enum Error {
     /// Failed to decode the field data as `JSON` in
     /// [`field.json()`](./struct.Field.html#method.json) method.
     #[cfg(feature = "json")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    #[cfg_attr(nightly, doc(cfg(feature = "json")))]
     #[display(fmt = "failed to decode field data as JSON: {}", _0)]
     DecodeJson(serde_json::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,7 @@ pub enum Error {
     /// Failed to decode the field data as `JSON` in
     /// [`field.json()`](./struct.Field.html#method.json) method.
     #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     #[display(fmt = "failed to decode field data as JSON: {}", _0)]
     DecodeJson(serde_json::Error),
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -206,6 +206,7 @@ impl Field {
     /// or it cannot be properly deserialized to target type `T`. For more
     /// details please see [`serde_json::from_slice`](https://docs.serde.rs/serde_json/fn.from_slice.html);
     #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub async fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
         serde_json::from_slice(&self.bytes().await?).map_err(crate::Error::DecodeJson)
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -206,7 +206,7 @@ impl Field {
     /// or it cannot be properly deserialized to target type `T`. For more
     /// details please see [`serde_json::from_slice`](https://docs.serde.rs/serde_json/fn.from_slice.html);
     #[cfg(feature = "json")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    #[cfg_attr(nightly, doc(cfg(feature = "json")))]
     pub async fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
         serde_json::from_slice(&self.bytes().await?).map_err(crate::Error::DecodeJson)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
     trivial_casts,
     unused_qualifications
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(nightly, feature(doc_cfg))]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@
     trivial_casts,
     unused_qualifications
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -140,6 +140,7 @@ impl Multipart {
     ///
     /// [`AsyncRead`]: https://docs.rs/futures-io/0.3.7/futures_io/trait.AsyncRead.html
     #[cfg(feature = "tokio-io")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
     pub fn with_reader<R, B>(reader: R, boundary: B) -> Multipart
     where
         R: AsyncRead + Unpin + Send + 'static,
@@ -176,6 +177,7 @@ impl Multipart {
     ///
     /// [`AsyncRead`]: https://docs.rs/futures-io/0.3.7/futures_io/trait.AsyncRead.html
     #[cfg(feature = "tokio-io")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
     pub fn with_reader_with_constraints<R, B>(reader: R, boundary: B, constraints: Constraints) -> Multipart
     where
         R: AsyncRead + Unpin + Send + 'static,

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -140,7 +140,7 @@ impl Multipart {
     ///
     /// [`AsyncRead`]: https://docs.rs/futures-io/0.3.7/futures_io/trait.AsyncRead.html
     #[cfg(feature = "tokio-io")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
+    #[cfg_attr(nightly, doc(cfg(feature = "tokio-io")))]
     pub fn with_reader<R, B>(reader: R, boundary: B) -> Multipart
     where
         R: AsyncRead + Unpin + Send + 'static,
@@ -177,7 +177,7 @@ impl Multipart {
     ///
     /// [`AsyncRead`]: https://docs.rs/futures-io/0.3.7/futures_io/trait.AsyncRead.html
     #[cfg(feature = "tokio-io")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
+    #[cfg_attr(nightly, doc(cfg(feature = "tokio-io")))]
     pub fn with_reader_with_constraints<R, B>(reader: R, boundary: B, constraints: Constraints) -> Multipart
     where
         R: AsyncRead + Unpin + Send + 'static,


### PR DESCRIPTION
Enables the `doc_cfg` feature if building documentation on docs.rs.