### PR TITLE
Remove unused `futures` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio-io = ["tokio", "tokio-util"]
 [dependencies]
 log = "0.4"
 bytes = "1.0"
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 twoway = "0.2"
 http = "0.2"
 httparse = "1.3"


### PR DESCRIPTION
The PR reduces the number of dependencies pulled by the futures crate.
```
$ cargo up
    Updating crates.io index
    Removing futures-executor v0.3.13
    Removing futures-macro v0.3.13
    Removing proc-macro-hack v0.5.19
    Removing proc-macro-nested v0.1.7
    Removing slab v0.4.2
```