### PR TITLE
Use reference instead of Arc<Mutex>

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,3 @@
-use std::task::Waker;
-
 use crate::buffer::StreamBuffer;
 
 #[derive(Debug)]
@@ -7,8 +5,6 @@ pub(crate) struct MultipartState {
     pub(crate) buffer: StreamBuffer,
     pub(crate) boundary: String,
     pub(crate) stage: StreamingStage,
-    pub(crate) is_prev_field_consumed: bool,
-    pub(crate) next_field_waker: Option<Waker>,
     pub(crate) next_field_idx: usize,
     pub(crate) curr_field_name: Option<String>,
     pub(crate) curr_field_size_limit: u64,
@@ -17,7 +13,6 @@ pub(crate) struct MultipartState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StreamingStage {
-    CleaningPrevFieldData,
     FindingFirstBoundary,
     ReadingBoundary,
     DeterminingBoundaryType,


### PR DESCRIPTION
This reduces the possibility of API misuse by enforcing one field at a time in the borrow checker itself. Unfortunately, we do lose out on implementing `Stream` on `Multipart`, but that API was a lie anyway since in practice only one `Field` can exist at a time.

Closes #7.