### PR TITLE
Replace twoway crate with memchr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio-io = ["tokio", "tokio-util"]
 log = "0.4"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false }
-twoway = "0.2"
+memchr = "2.4"
 http = "0.2"
 httparse = "1.3"
 mime = "0.3"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -22,14 +22,14 @@ impl ContentDispositionAttr {
             ContentDispositionAttr::FileName => &b"filename=\""[..],
         };
 
-        if let Some(i) = twoway::find_bytes(header, prefix) {
+        if let Some(i) = memchr::memmem::find(header, prefix) {
             // Check if this is malformed, with `filename` coming first.
             if *self == ContentDispositionAttr::Name && i > 0 && header[i - 1] == b'e' {
                 return None;
             }
 
             let rest = &header[(i + prefix.len())..];
-            if let Some(j) = twoway::find_bytes(rest, b"\"") {
+            if let Some(j) = memchr::memmem::find(rest, b"\"") {
                 return Some(&rest[..j]);
             }
         }


### PR DESCRIPTION
The twoway crate has been deprecated, as can be seen from the first line of the [docs](https://docs.rs/twoway/0.2.2/twoway/)