### PR TITLE
Add support for unquoted names and filenames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ http = "0.2"
 httparse = "1.3"
 mime = "0.3"
 encoding_rs = "0.8"
+percent-encoding = "2.1"
 spin = { version = "0.9", default-features = false, features = ["spin_mutex"] }
 
 serde = { version = "1.0", optional = true }

--- a/src/content_disposition.rs
+++ b/src/content_disposition.rs
@@ -14,12 +14,10 @@ impl ContentDisposition {
 
         let field_name = content_disposition
             .and_then(|val| ContentDispositionAttr::Name.extract_from(val))
-            .and_then(|attr| std::str::from_utf8(attr).ok())
             .map(String::from);
 
         let file_name = content_disposition
             .and_then(|val| ContentDispositionAttr::FileName.extract_from(val))
-            .and_then(|attr| std::str::from_utf8(attr).ok())
             .map(String::from);
 
         ContentDisposition { field_name, file_name }


### PR DESCRIPTION
Adds support for unquoted names and filenames, for compatibility with
older clients that may not quote them. If they are not quoted, they must
be percent encoded.