### PR TITLE
Replace unmaintained `actions-rs/*` actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,22 +23,15 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Install ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        override: true
 
     - name: check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --bins --examples --features=all
+      run: cargo check --all --bins --examples --all-features
 
     - name: tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --features=all
+      run: cargo test --all --all-features
 
   check_fmt_and_docs:
     name: Checking fmt, clippy, and docs


### PR DESCRIPTION
The toolchain is now installed via `dtolnay/rust-toolchain`.