### PR TITLE
Fix: extract_from is too strict

### DIFF
--- a/fuzz/corpus/fuzz_multipart_bytes/inverted_simple2.seed
+++ b/fuzz/corpus/fuzz_multipart_bytes/inverted_simple2.seed
@@ -1,0 +1,10 @@
+--X-BOUNDARY
+Content-Disposition: form-data; name="field1"
+
+value1
+--X-BOUNDARY
+Content-Disposition: form-data; filename="example.txt"; name="field2"
+
+value2
+--X-BOUNDARY--
+

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -18,35 +18,88 @@ pub(crate) enum ContentDispositionAttr {
 impl ContentDispositionAttr {
     /// Extract ContentDisposition Attribute from header.
     ///
-    /// Some older clients may not quote the name or filename, so we allow them
+    /// Some older clients may not quote the name or filename, so we allow them,
+    /// but require them to be percent encoded. Only allocates if percent
+    /// decoding, and there are characters that need to be decoded.
     pub fn extract_from<'h>(&self, header: &'h [u8]) -> Option<&'h [u8]> {
         let prefix = match self {
             ContentDispositionAttr::Name => &b"name="[..],
             ContentDispositionAttr::FileName => &b"filename="[..],
         };
+        let prefix_finder = memchr::memmem::Finder::new(prefix);
 
-        if let Some(i) = memchr::memmem::find(header, prefix) {
-            // Check if this is malformed, with `filename` coming first.
-            if *self == ContentDispositionAttr::Name && i > 0 && header[i - 1] == b'e' {
-                return None;
+        let mut rest = header;
+
+        // find form-data;
+        rest = Self::skip_pattern(b"form-data", rest);
+
+        // skip separator
+        rest = Self::skip_separator(rest);
+
+        let mut last_length = rest.len();
+        while rest.len() > prefix.len() {
+            let m = prefix_finder.find(rest);
+            match m {
+                Some(0) => {
+                    // skip prefix
+                    rest = &rest[prefix.len()..];
+
+                    // parse value
+                    let (parsed, _to) = Self::parse_value(rest)?;
+                    return Some(parsed);
+                }
+                _ => {
+                    // skip prefix
+                    let skip_chars = memchr::memchr(b'=', rest)? + 1;
+                    rest = &rest[skip_chars..];
+
+                    // skip value
+                    let (_parsed, new_rest) = Self::parse_value(rest)?;
+                    rest = new_rest;
+                }
             }
 
-            // Handle quoted strings first, then unquoted string.
-            // FIXME: According to RFC6266 4.1, a 'quoted-string' (RFC 2616 2.2)
-            // can contain a 'quoted-pair', which can be used to escape a quote
-            // character in a name with `\`. That is, "a\"b" is a valid name.
-            // But this routine would truncate it to `a\`; this is wrong.
-            let rest = &header[(i + prefix.len())..];
-            if rest.starts_with(b"\"") {
-                let k = memchr::memchr(b'"', &rest[1..])?;
-                return Some(&rest[1..(k + 1)]);
-            } else {
-                let j = memchr::memchr(b';', rest).unwrap_or(rest.len());
-                return Some(&rest[..j]);
+            // skip spacer
+            rest = Self::skip_separator(rest);
+
+            // break if fix point reached
+            if rest.len() >= last_length {
+                break;
             }
+
+            last_length = rest.len();
         }
 
         None
+    }
+
+    fn skip_pattern<'a, 'b>(pattern: &'a [u8], mut rest: &'b [u8]) -> &'b [u8] {
+        if rest.starts_with(pattern) {
+            rest = &rest[pattern.len()..];
+        }
+
+        rest
+    }
+
+    fn skip_separator(mut rest: &[u8]) -> &[u8] {
+        // skip semicolumn
+        rest = Self::skip_pattern(b";", rest);
+
+        // skip spaces
+        let spaces = rest.iter().position(|v| *v != b' ').unwrap_or(0);
+        &rest[spaces..]
+    }
+
+    /// Parse initial part of the slice for a header value (both quoted and not).
+    /// Returns the parsed value and the remaining content of the slice
+    fn parse_value(rest: &[u8]) -> Option<(&[u8], &[u8])> {
+        if rest.starts_with(b"\"") {
+            let last_quote = memchr::memchr_iter(b'"', rest).skip(1).find(|i| rest[i - 1] != b'\\')?;
+            Some((&rest[1..last_quote], &rest[last_quote + 1..]))
+        } else {
+            let j = memchr::memchr(b';', rest).unwrap_or(rest.len());
+            Some((&rest[0..j], &rest[j..]))
+        }
     }
 }
 
@@ -99,6 +152,27 @@ mod tests {
         let filename = ContentDispositionAttr::FileName.extract_from(val);
         assert_eq!(filename.unwrap(), "কখগ-你好.txt".as_bytes());
         assert!(name.is_none());
+    }
+
+    #[test]
+    fn test_content_distribution_misordered_fields() {
+        let val = br#"form-data; filename=file-name.txt; name=file"#;
+        let name = ContentDispositionAttr::Name.extract_from(val);
+        let filename = ContentDispositionAttr::FileName.extract_from(val);
+        assert_eq!(filename.unwrap(), b"file-name.txt");
+        assert_eq!(name.unwrap(), b"file");
+
+        let val = br#"form-data; filename="file-name.txt"; name="file""#;
+        let name = ContentDispositionAttr::Name.extract_from(val);
+        let filename = ContentDispositionAttr::FileName.extract_from(val);
+        assert_eq!(filename.unwrap(), b"file-name.txt");
+        assert_eq!(name.unwrap(), b"file");
+
+        let val = "form-data; filename=\"你好.txt\"; name=\"কখগ\"".as_bytes();
+        let name = ContentDispositionAttr::Name.extract_from(val);
+        let filename = ContentDispositionAttr::FileName.extract_from(val);
+        assert_eq!(name.unwrap(), "কখগ".as_bytes());
+        assert_eq!(filename.unwrap(), "你好.txt".as_bytes());
     }
 
     #[test]


### PR DESCRIPTION
`ContentDispositionAttr::extract_from` is too strict, requiring form-data fileds to be in a specific order. The standard also allows `name` and `filename` arguments to swap their position.

This commit:
- makes the extractor match the standard
- adds regression tests
- adds a fuzz configuration including swapped arguments

Both tests and fuzzing are passing. Performance regression needs to be tested.