### PR TITLE
Prevent accidental double-boxing of `StreamReadFailed` errors

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -339,7 +339,7 @@ impl Stream for Field<'_> {
 
         let state = &mut *lock;
         if let Err(err) = state.buffer.poll_stream(cx) {
-            return Poll::Ready(Some(Err(crate::Error::StreamReadFailed(err.into()))));
+            return Poll::Ready(Some(Err(err)));
         }
 
         match state

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -251,9 +251,7 @@ impl<'r> Multipart<'r> {
             return Poll::Ready(Ok(None));
         }
 
-        if let Err(err) = state.buffer.poll_stream(cx) {
-            return Poll::Ready(Err(crate::Error::StreamReadFailed(err.into())));
-        }
+        state.buffer.poll_stream(cx)?;
 
         if state.stage == StreamingStage::FindingFirstBoundary {
             let boundary = &state.boundary;
@@ -261,9 +259,7 @@ impl<'r> Multipart<'r> {
             match state.buffer.read_to(boundary_deriv.as_bytes()) {
                 Some(_) => state.stage = StreamingStage::ReadingBoundary,
                 None => {
-                    if let Err(err) = state.buffer.poll_stream(cx) {
-                        return Poll::Ready(Err(crate::Error::StreamReadFailed(err.into())));
-                    }
+                    state.buffer.poll_stream(cx)?;
                     if state.buffer.eof {
                         return Poll::Ready(Err(crate::Error::IncompleteStream));
                     }


### PR DESCRIPTION
Since the inner stream [already wraps the error in `StreamReadFailed`](https://github.com/rousan/multer-rs/blob/master/src/multipart.rs#L126), there’s no need to do it again.