### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ http = "0.2"
 httparse = "1.3"
 mime = "0.3"
 encoding_rs = "0.8"
-spin = { version = "0.9", default-features = false, features = ["spin_mutex"] }
+spin = { version = "0.9.8", default-features = false, features = ["spin_mutex"] }
 
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)