### PR TITLE
Detect multiple boundary values

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,9 @@ pub enum Error {
     /// No boundary found in `Content-Type` header.
     NoBoundary,
 
+    /// More than one boundary found in `Content-Type` header.
+    MultipleBoundaries,
+
     /// Failed to decode the field data as `JSON` in
     /// [`field.json()`](crate::Field::json) method.
     #[cfg(feature = "json")]
@@ -96,6 +99,7 @@ impl Display for Error {
             Error::LockFailure => write!(f, "failed to lock multipart state"),
             Error::NoMultipart => write!(f, "Content-Type is not multipart/form-data"),
             Error::NoBoundary => write!(f, "multipart boundary not found in Content-Type"),
+            Error::MultipleBoundaries => write!(f, "multipart boundary found multiple times in Content-Type"),
             #[cfg(feature = "json")]
             Error::DecodeJson(_) => write!(f, "failed to decode field data as JSON"),
         }
@@ -120,7 +124,8 @@ impl std::error::Error for Error {
             | Error::StreamSizeExceeded { .. }
             | Error::LockFailure
             | Error::NoMultipart
-            | Error::NoBoundary => None,
+            | Error::NoBoundary
+            | Error::MultipleBoundaries => None,
         }
     }
 }


### PR DESCRIPTION
Run into a stuck multipart parsing (in axum), because a request had two boundaries within the header like this:

`Content-Type: multipart/form-data; boundary=---------------------------17832986845363619572950809769; boundary=------------------------bjsYDym0V6iqcnC7ILHUdu`

The parser used the first value and never succeeded in finding a part, it did even blocked the whole connection.

This change detects multiple values for `boundary` and prevents a dead lock.